### PR TITLE
Throw error when building an invalid key

### DIFF
--- a/src/attributes/attribute_info.ts
+++ b/src/attributes/attribute_info.ts
@@ -163,7 +163,13 @@ export class AttributeInfo {
         }
 
         // Build and return the key string.
-        return [pid, ...fields].join(':');
+        const newKey = [pid, ...fields].join(':');
+
+        if (this.catalog.hasKey(newKey)) {
+            return newKey;
+        } else {
+            throw TypeError(`Invalid attribute set for pid:${pid}`);
+        }
     }
 
     getAttributes(key: Key): AID[] {

--- a/test/attributes/attribute_info.test.ts
+++ b/test/attributes/attribute_info.test.ts
@@ -19,6 +19,7 @@ import {
     flavor,
     flavorChocolate,
     flavorDimension,
+    flavorForbidden,
     flavorVanilla,
     genericCone,
     mediumVanillaCone,
@@ -125,6 +126,11 @@ describe('AttributeInfo', () => {
             info.getKey(genericConePID, dimensionIdToAttribute),
             `${genericConePID}:1:0`
         );
+
+        dimensionIdToAttribute.set(flavor, flavorForbidden);
+
+        const f = () => info['getKey'](genericConePID, dimensionIdToAttribute);
+        assert.throws(f, 'Invalid attribute set for pid:8000');
     });
 
     it('getAttributes()', () => {

--- a/test/shared/small_world.ts
+++ b/test/shared/small_world.ts
@@ -96,6 +96,7 @@ export const sizes: AttributeDescription[] = [
 
 export const flavorVanilla: AID = 2;
 export const flavorChocolate: AID = 3;
+export const flavorForbidden: AID = 666;
 
 export const flavors: AttributeDescription[] = [
     {
@@ -107,6 +108,11 @@ export const flavors: AttributeDescription[] = [
         aid: flavorChocolate,
         name: 'chocolate',
         aliases: ['chocolate'],
+    },
+    {
+        aid: flavorForbidden,
+        name: 'forbiddenFruit',
+        aliases: ['forbidden'],
     },
 ];
 


### PR DESCRIPTION
Fix #84 

`AttributeInfo` throws an error when given an attribute set and PID that generates a key that is not present within the catalog.