### PR TITLE
Add evaluateIntermediate flag to pass on final cart only

### DIFF
--- a/samples/test_suite_demo.ts
+++ b/samples/test_suite_demo.ts
@@ -24,6 +24,7 @@ async function go() {
     const showAll = args['a'] === true;
     const suiteFilter = args['s'];
     const isomorphic = args['i'] === true;
+    const finalCartOnly = args['final'] === true;
 
     if (suiteFilter) {
         console.log(`Running tests in suite: ${suiteFilter}`);
@@ -43,7 +44,8 @@ async function go() {
         nopProcessor,
         world.catalog,
         suiteFilter,
-        isomorphic
+        isomorphic,
+        !finalCartOnly
     );
     aggregator.print(showAll, isomorphic);
 }

--- a/src/test_suite/test_suite.ts
+++ b/src/test_suite/test_suite.ts
@@ -308,7 +308,7 @@ export class TestCase {
                 const observed = formatCart(state.cart, catalog);
                 orders.push(observed);
 
-                if (succeeded && (evaluateIntermediate || this.inputs.length - 1 === i)) {
+                if (succeeded && (evaluateIntermediate || i === this.inputs.length - 1)) {
                     // Compare observed Orders
                     const expected = this.expected[i];
                     succeeded = isomorphic


### PR DESCRIPTION
There was actually an unintended bug where unless there was an exception, the final cart state was determining the pass/fail of the entire test case. While this is actually the behavior we want now, this flag introduces the ability to validate the intermediate cart states by default, but allows an override to pass/fail only on the final cart state
