### PR TITLE
Add toJUnitXML to test runner result classes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -151,6 +151,12 @@
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.1.tgz",
       "integrity": "sha512-SGGAhXLHDx+PK4YLNcNGa6goPf9XRWQNAUUbffkwVGGXIxmDKWyGGL4inzq2sPmExu431Ekb9aEMn9BkPqEYFA=="
     },
+    "@types/jsontoxml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsontoxml/-/jsontoxml-1.0.1.tgz",
+      "integrity": "sha512-Vv8V/nKxSLK/3lErSb3c6pMZWv/KudTKFnUA6/2xZO9jszRUJqMv6SHTb7acQp1wWUAa7RP3KYFic8zSRdDxlA==",
+      "dev": true
+    },
     "@types/minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
@@ -1599,6 +1605,11 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "jsontoxml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/jsontoxml/-/jsontoxml-1.0.1.tgz",
+      "integrity": "sha512-dtKGq0K8EWQBRqcAaePSgKR4Hyjfsz/LkurHSV3Cxk4H+h2fWDeaN2jzABz+ZmOJylgXS7FGeWmbZ6jgYUMdJQ=="
     },
     "jsprim": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@types/dotenv": "^6.1.1",
     "@types/fs-extra": "^7.0.0",
     "@types/js-yaml": "^3.12.1",
+    "@types/jsontoxml": "^1.0.1",
     "@types/minimist": "^1.2.0",
     "@types/mocha": "^5.2.6",
     "@types/node": "^12.0.0",
@@ -84,6 +85,7 @@
     "debug": "^4.1.1",
     "dotenv": "^8.0.0",
     "js-yaml": "^3.13.1",
+    "jsontoxml": "^1.0.1",
     "minimist": "^1.2.0"
   },
   "prettier": {


### PR DESCRIPTION
This change allows PrixFixe test runner changes to be consumed by
CI pipelines that use the JUnit XML format for recording test results