### PR TITLE
Don't allow two items with same PID in cart

### DIFF
--- a/src/cart/cart_ops.ts
+++ b/src/cart/cart_ops.ts
@@ -63,18 +63,21 @@ export class CartOps implements ICartOps {
         child: ItemInstance
     ): ItemInstance {
         let inserted = false;
-        const f = this.ruleChecker.getPairwiseMutualExclusionPredicate(
-            parent.key,
-            child.key
+        const f = this.ruleChecker.getIncrementalMutualExclusionPredicate(
+            parent.key
         );
         const newChildren: ItemInstance[] = [];
         for (const c of parent.children) {
-            if (f(c.key)) {
-                newChildren.push(c);
-            } else {
-                if (!inserted) {
-                    inserted = true;
-                    newChildren.push(child);
+            const existingPID = AttributeInfo.pidFromKey(c.key).toString();
+            const childPID = AttributeInfo.pidFromKey(child.key).toString();
+            if (existingPID !== childPID) {
+                if (f(c.key)) {
+                    newChildren.push(c);
+                } else {
+                    if (!inserted) {
+                        inserted = true;
+                        newChildren.push(child);
+                    }
                 }
             }
         }

--- a/src/rule_checker/interfaces.ts
+++ b/src/rule_checker/interfaces.ts
@@ -53,6 +53,8 @@ export interface IRuleChecker {
     getValidChildren(parent: Key): Set<PID>;
 
     /**
+     * @deprecated Please use getIncrementalMutualExclusionPredicate
+     *
      * Given the key of a parent item (parent) and the key of a child item
      * (child) return a curried function that indicates whether another child
      * (existing) would violate mutual exclusivity.

--- a/src/rule_checker/rule_checker.ts
+++ b/src/rule_checker/rule_checker.ts
@@ -1,3 +1,4 @@
+import { AttributeInfo } from '../attributes';
 import { CID, PID, Key, GenericTypedEntity } from '../catalog';
 
 import {
@@ -128,7 +129,7 @@ export class RuleChecker implements IRuleChecker {
         ) as MutualExclusionZone[];
 
         const exclusionCIDs = new Set<CID>();
-        const childPID = child.split(':')[0];
+        const childPID = AttributeInfo.pidFromKey(child).toString();
         for (const predicate of predicates) {
             const childCID = predicate(childPID);
             if (childCID > -1) {
@@ -137,8 +138,8 @@ export class RuleChecker implements IRuleChecker {
         }
 
         return (existing: Key): boolean => {
-            const existingPID = existing.split(':')[0];
-            const childPID = child.split(':')[0];
+            const existingPID = AttributeInfo.pidFromKey(existing).toString();
+            const childPID = AttributeInfo.pidFromKey(child).toString();
 
             if (existing === child) {
                 return false;
@@ -190,7 +191,7 @@ export class RuleChecker implements IRuleChecker {
 
             children.add(child);
 
-            const childPID = child.split(':')[0];
+            const childPID = AttributeInfo.pidFromKey(child).toString();
             const thisChildCIDs = new Set<CID>();
             for (const predicate of predicates) {
                 const childCID = predicate(childPID);

--- a/src/rule_checker/rule_checker.ts
+++ b/src/rule_checker/rule_checker.ts
@@ -137,11 +137,13 @@ export class RuleChecker implements IRuleChecker {
         }
 
         return (existing: Key): boolean => {
+            const existingPID = existing.split(':')[0];
+            const childPID = child.split(':')[0];
+
             if (existing === child) {
                 return false;
             }
 
-            const existingPID = existing.split(':')[0];
             for (const predicate of predicates) {
                 const existingCID = predicate(existingPID);
                 if (existingCID > -1) {
@@ -150,6 +152,11 @@ export class RuleChecker implements IRuleChecker {
                     }
                 }
             }
+
+            if (existingPID === childPID) {
+                return false;
+            }
+
             return true;
         };
     }

--- a/src/rule_checker/rule_checker.ts
+++ b/src/rule_checker/rule_checker.ts
@@ -144,6 +144,10 @@ export class RuleChecker implements IRuleChecker {
                 return false;
             }
 
+            if (existingPID === childPID) {
+                return false;
+            }
+
             for (const predicate of predicates) {
                 const existingCID = predicate(existingPID);
                 if (existingCID > -1) {
@@ -151,10 +155,6 @@ export class RuleChecker implements IRuleChecker {
                         return false;
                     }
                 }
-            }
-
-            if (existingPID === childPID) {
-                return false;
             }
 
             return true;

--- a/test/cart/cart_ops.test.ts
+++ b/test/cart/cart_ops.test.ts
@@ -84,7 +84,7 @@ const whippedCreamItem: ItemInstance = {
 };
 
 const noWhippedCreamItem: ItemInstance = {
-    uid: 6,
+    uid: 7,
     key: noWhippedCream.key,
     quantity: 1,
     children: [],

--- a/test/cart/cart_ops.test.ts
+++ b/test/cart/cart_ops.test.ts
@@ -21,6 +21,8 @@ import {
     soyMilk,
     temperatureCold,
     wholeMilk,
+    whippedCream,
+    noWhippedCream,
 } from '../shared';
 
 const sampleCart: Cart = {
@@ -117,6 +119,61 @@ describe('CartOps', () => {
             // Make sure original was left unchanged.
             assert.deepEqual(original, smallVanillaConeItem);
         });
+
+        it('Add to ItemInstance With Replacement', () => {
+            const original = { ...smallVanillaConeItem };
+            const modified = ops.addToItemWithReplacement(
+                original,
+                smallCoffeeItem
+            );
+
+            // Look for the correct change.
+            assert.deepEqual(modified, {
+                ...original,
+                children: [smallCoffeeItem],
+            });
+
+            // Make sure original was left unchanged.
+            assert.deepEqual(original, smallVanillaConeItem);
+        });
+
+        it('Add to ItemInstance With Replacement (Same PID)', () => {
+            const whippedCreamItem: ItemInstance = {
+                uid: 6,
+                key: whippedCream.key,
+                quantity: 1,
+                children: [],
+            };
+
+            const noWhippedCreamItem: ItemInstance = {
+                uid: 6,
+                key: noWhippedCream.key,
+                quantity: 1,
+                children: [],
+            };
+
+            let cart: Cart = { items: [] };
+
+            const coffeeWithWhippedCream = ops.addToItem(
+                smallCoffeeItem,
+                whippedCreamItem
+            );
+            const coffeeWithoutWhippedCream = ops.addToItemWithReplacement(
+                coffeeWithWhippedCream,
+                noWhippedCreamItem
+            );
+
+            cart = ops.addToCart(cart, coffeeWithWhippedCream);
+
+            assert.deepEqual(cart.items, [
+                { ...cart.items[0], children: [whippedCreamItem] },
+            ]);
+
+            const cart2 = ops.replaceInCart(cart, coffeeWithoutWhippedCream);
+            assert.deepEqual(cart2.items, [
+                { ...cart2.items[0], children: [noWhippedCreamItem] },
+            ]);
+        });
     });
 
     ///////////////////////////////////////////////////////////////////////////
@@ -142,7 +199,7 @@ describe('CartOps', () => {
 
             // The second item in the sample cart is a smallCoffee that has a
             // soyMilk child with UID 4. Attempt to replace this child with
-            // whoteMilk.
+            // wholeMilk.
             const wholeMilkItem: ItemInstance = {
                 uid: 4,
                 key: wholeMilk.key,

--- a/test/cart/cart_ops.test.ts
+++ b/test/cart/cart_ops.test.ts
@@ -76,6 +76,20 @@ const smallCoffeeItem: ItemInstance = {
     children: [],
 };
 
+const whippedCreamItem: ItemInstance = {
+    uid: 6,
+    key: whippedCream.key,
+    quantity: 1,
+    children: [],
+};
+
+const noWhippedCreamItem: ItemInstance = {
+    uid: 6,
+    key: noWhippedCream.key,
+    quantity: 1,
+    children: [],
+};
+
 const attributeInfo = new AttributeInfo(
     smallWorldCatalog,
     smallWorldAttributes
@@ -138,40 +152,26 @@ describe('CartOps', () => {
         });
 
         it('Add to ItemInstance With Replacement (Same PID)', () => {
-            const whippedCreamItem: ItemInstance = {
-                uid: 6,
-                key: whippedCream.key,
-                quantity: 1,
-                children: [],
-            };
-
-            const noWhippedCreamItem: ItemInstance = {
-                uid: 6,
-                key: noWhippedCream.key,
-                quantity: 1,
-                children: [],
-            };
-
             let cart: Cart = { items: [] };
 
             const coffeeWithWhippedCream = ops.addToItem(
                 smallCoffeeItem,
                 whippedCreamItem
             );
+
+            cart = ops.addToCart(cart, coffeeWithWhippedCream);
+            assert.deepEqual(cart.items, [
+                { ...cart.items[0], children: [whippedCreamItem] },
+            ]);
+
             const coffeeWithoutWhippedCream = ops.addToItemWithReplacement(
                 coffeeWithWhippedCream,
                 noWhippedCreamItem
             );
 
-            cart = ops.addToCart(cart, coffeeWithWhippedCream);
-
+            cart = ops.replaceInCart(cart, coffeeWithoutWhippedCream);
             assert.deepEqual(cart.items, [
-                { ...cart.items[0], children: [whippedCreamItem] },
-            ]);
-
-            const cart2 = ops.replaceInCart(cart, coffeeWithoutWhippedCream);
-            assert.deepEqual(cart2.items, [
-                { ...cart2.items[0], children: [noWhippedCreamItem] },
+                { ...cart.items[0], children: [noWhippedCreamItem] },
             ]);
         });
     });

--- a/test/rule_checker/rule_checker.test.ts
+++ b/test/rule_checker/rule_checker.test.ts
@@ -298,6 +298,23 @@ describe('RuleChecker', () => {
         });
     });
 
+    describe('getPairwiseMutualExclusionPredicate()', () => {
+        it('general', () => {
+            // tslint:disable-next-line: deprecation
+            const f = ruleChecker.getPairwiseMutualExclusionPredicate(
+                latteHotKey,
+                wholeMilkKey
+            );
+
+            assert.isFalse(f(wholeMilkKey));
+            assert.isTrue(f(someOtherKey1));
+            assert.isFalse(f(soyMilkKey));
+            assert.isTrue(f(someOtherKey2));
+            assert.isFalse(f(twoMilkKey));
+            assert.isFalse(f(someOtherKey2));
+        });
+    });
+
     describe('Default quantity', () => {
         it('Fetches the correct default quantity for top level rules', () => {
             // Milks should all be one

--- a/test/rule_checker/rule_checker.test.ts
+++ b/test/rule_checker/rule_checker.test.ts
@@ -185,17 +185,18 @@ const largeIced: Key = '9000:1:2';
 const drizzleKey: Key = '6000:1:0';
 const anotherDrizzleKey: Key = '6000:1:2';
 const sprinklesKey: Key = '7000:2';
-const anotherSprinleKey: Key = '7000:1';
+const anotherSprinkleKey: Key = '7000:1';
 
 const soyMilkKey: Key = '5000:3';
 const twoMilkKey: Key = '5000:1';
 const wholeMilkKey: Key = '5000:0';
 
 const whippedCreamKey: Key = '2000:2';
+const noWhippedCreamKey: Key = '2000:0';
 
 // The following two keys are not mutually exclusive with any others.
 const someOtherKey1: Key = '9999:1';
-const someOtherKey2: Key = '9999:2';
+const someOtherKey2: Key = '1111:2';
 
 const ruleChecker: IRuleChecker = new RuleChecker(SAMPLE_RULES, genericMap);
 
@@ -226,7 +227,7 @@ describe('RuleChecker', () => {
         it('Invalid children evaluate to false (4)', () => {
             // More sprinkles also don't belong in lattes
             assert.isFalse(
-                ruleChecker.isValidChild(latteHotKey, anotherSprinleKey)
+                ruleChecker.isValidChild(latteHotKey, anotherSprinkleKey)
             );
         });
 
@@ -240,7 +241,7 @@ describe('RuleChecker', () => {
         it('Invalid children evaluate to false (6)', () => {
             // More sprinkles cannot be in an iced latte
             assert.isFalse(
-                ruleChecker.isValidChild(latteIcedKey, anotherSprinleKey)
+                ruleChecker.isValidChild(latteIcedKey, anotherSprinkleKey)
             );
         });
 
@@ -289,6 +290,14 @@ describe('RuleChecker', () => {
             assert.isTrue(f(someOtherKey2));
             assert.isTrue(f(wholeMilkKey));
             assert.isTrue(f(twoMilkKey));
+        });
+
+        it('same pid', () => {
+            const f = ruleChecker.getPairwiseMutualExclusionPredicate(
+                latteIcedKey,
+                whippedCreamKey
+            );
+            assert.isFalse(f(noWhippedCreamKey));
         });
     });
 

--- a/test/rule_checker/rule_checker.test.ts
+++ b/test/rule_checker/rule_checker.test.ts
@@ -270,37 +270,6 @@ describe('RuleChecker', () => {
         });
     });
 
-    describe('getPairwiseMutualExclusionPredicate()', () => {
-        it('general', () => {
-            const f = ruleChecker.getPairwiseMutualExclusionPredicate(
-                latteHotKey,
-                soyMilkKey
-            );
-            assert.isFalse(f(wholeMilkKey));
-            assert.isTrue(f(someOtherKey1));
-            assert.isFalse(f(twoMilkKey));
-        });
-
-        it('self exclusion', () => {
-            const f = ruleChecker.getPairwiseMutualExclusionPredicate(
-                latteHotKey,
-                someOtherKey1
-            );
-            assert.isFalse(f(someOtherKey1));
-            assert.isTrue(f(someOtherKey2));
-            assert.isTrue(f(wholeMilkKey));
-            assert.isTrue(f(twoMilkKey));
-        });
-
-        it('same pid', () => {
-            const f = ruleChecker.getPairwiseMutualExclusionPredicate(
-                latteIcedKey,
-                whippedCreamKey
-            );
-            assert.isFalse(f(noWhippedCreamKey));
-        });
-    });
-
     describe('getIncrementalMutualExclusionPredicate()', () => {
         it('general', () => {
             const f = ruleChecker.getIncrementalMutualExclusionPredicate(

--- a/test/shared/small_world.ts
+++ b/test/shared/small_world.ts
@@ -383,6 +383,20 @@ export const soyMilk: SpecificTypedEntity = {
     kind: OPTION,
 };
 
+export const whippedCream: SpecificTypedEntity = {
+    sku: 2002,
+    name: 'with whipped cream',
+    key: '2000:2',
+    kind: OPTION,
+};
+
+export const noWhippedCream: SpecificTypedEntity = {
+    sku: 2000,
+    name: 'with no whipped cream',
+    key: '2000:0',
+    kind: OPTION,
+};
+
 export const specificItems: SpecificTypedEntity[] = [
     smallVanillaCone,
     smallChocolateCone,
@@ -400,6 +414,8 @@ export const specificItems: SpecificTypedEntity[] = [
     twoMilk,
     zeroMilk,
     soyMilk,
+    whippedCream,
+    noWhippedCream,
 ];
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR fixes bug #95 and addresses task #97 

Adding a check to see if an child item with the same PID is there to stop the scenario where we have the same PID option x number of times. 
