### PR TITLE
WIP: parser for suite filter expressions

### DIFF
--- a/src/test_suite/index.ts
+++ b/src/test_suite/index.ts
@@ -1,5 +1,7 @@
+export * from './peekable_sequence';
 export * from './print_markdown';
 export * from './statistics_aggregator';
+export * from './suite_filter';
 export * from './test_processors';
 export * from './test_runner_main';
 export * from './test_suite';

--- a/src/test_suite/peekable_sequence.ts
+++ b/src/test_suite/peekable_sequence.ts
@@ -25,6 +25,7 @@ export class PeekableSequence<T> {
         }
     }
 
+    // Returns true if we're at the end of the stream (EOS)
     atEOS(): boolean {
         return this.current.done;
     }

--- a/src/test_suite/peekable_sequence.ts
+++ b/src/test_suite/peekable_sequence.ts
@@ -1,0 +1,47 @@
+export class PeekableSequence<T> {
+    iterator: IterableIterator<T>;
+    current: IteratorResult<T>;
+
+    constructor(iterator: IterableIterator<T>) {
+        this.iterator = iterator;
+        this.current = this.iterator.next();
+    }
+
+    peek(): T {
+        if (!this.current.done) {
+            return this.current.value;
+        } else {
+            throw TypeError('PeekableSequence<T>.peek(): at end of stream.');
+        }
+    }
+
+    get(): T {
+        if (!this.current.done) {
+            const value = this.current.value;
+            this.current = this.iterator.next();
+            return value;
+        } else {
+            throw TypeError('PeekableSequence<T>.get(): at end of stream.');
+        }
+    }
+
+    atEOS(): boolean {
+        return this.current.done;
+    }
+
+    skip(value: T): boolean {
+        if (!this.atEOS() && this.peek() === value) {
+            this.get();
+            return true;
+        }
+        return false;
+    }
+
+    nextIs(value: T): boolean {
+        if (!this.atEOS()) {
+            return this.peek() === value;
+        }
+
+        return false;
+    }
+}

--- a/src/test_suite/statistics_aggregator.ts
+++ b/src/test_suite/statistics_aggregator.ts
@@ -14,10 +14,12 @@ export class StatisticsAggregator {
         this.values.push(value);
     }
 
-    computeStatistics(percentileKeys: number[]): Statistics {
+    // Generate a Statictics object if one or more values have been recorded.
+    // Otherwise return null.
+    computeStatistics(percentileKeys: number[]): Statistics | null {
         if (this.values.length < 1) {
-            const message = 'computeStatistics: need at least one value.';
-            throw TypeError(message);
+            // There are no values on which to compute statistics.
+            return null;
         }
 
         const values = [...this.values].sort((a, b) => a - b);

--- a/src/test_suite/suite_filter.ts
+++ b/src/test_suite/suite_filter.ts
@@ -1,0 +1,124 @@
+import { PeekableSequence } from './peekable_sequence';
+
+type SuitePredicate = (suites: string[]) => boolean;
+
+// Constructs a SuitePredicate from a a textual boolean expression
+// over suite names. The expression can be made up of
+//   TERM: a suite name - any sequence of non-space characters that
+//         does not include the symbols '(', ')', '&', '|', and '!'
+//   LOGICAL OR: '|'
+//   LOGICAL AND: '&'
+//   LOGICAL NEGATION: '!'
+//   PARENTHESES: '(', ')'
+//
+// The SuitePredicate takes a single parameter that is an array of
+// TERMS, each of which is considered to have a true value. It returns
+// the truth value of the expression.
+export function suiteFilter(text: string): SuitePredicate {
+    // Tokenzize the input string.
+    // The result should be an array of suite names, and symbols '(', ')', '&',
+    // '|', and '!'.
+    const re = new RegExp('s*([\\s+|\\&\\|\\!\\(\\)])');
+    const tokens = text
+        .split(re)
+        .map(x => x.trim())
+        .filter(x => x.length > 0);
+
+    // Create a stream of tokens.
+    const input = new PeekableSequence<string>(tokens.values());
+
+    return parseDisjunction(input);
+}
+
+// CONJUNCTION [| DISJUNCTION]*
+function parseDisjunction(input: PeekableSequence<string>): SuitePredicate {
+    const children: SuitePredicate[] = [parseConjunction(input)];
+    while (!input.atEOS()) {
+        if (input.peek() === ')') {
+            break;
+        } else if (input.peek() === '|') {
+            input.get();
+            children.push(parseConjunction(input));
+        } else {
+            const message = "Expected '&' or '|' operator";
+            throw TypeError(message);
+        }
+    }
+
+    if (children.length === 1) {
+        return children[0];
+    } else {
+        return (suites: string[]) => {
+            for (const child of children) {
+                if (child(suites)) {
+                    return true;
+                }
+            }
+            return false;
+        };
+    }
+}
+
+// UNARY [& CONJUNCTION]*
+function parseConjunction(input: PeekableSequence<string>): SuitePredicate {
+    const children: SuitePredicate[] = [parseUnary(input)];
+    while (!input.atEOS()) {
+        if (input.peek() === ')') {
+            break;
+        } else if (input.peek() === '&') {
+            input.get();
+            children.push(parseConjunction(input));
+        } else {
+            break;
+        }
+    }
+
+    if (children.length === 1) {
+        return children[0];
+    } else {
+        return (suites: string[]) => {
+            for (const child of children) {
+                if (!child(suites)) {
+                    return false;
+                }
+            }
+            return true;
+        };
+    }
+}
+
+// TERM | !TERM
+function parseUnary(input: PeekableSequence<string>): SuitePredicate {
+    if (input.nextIs('!')) {
+        input.get();
+        const unary = parseDisjunction(input);
+        return (suites: string[]) => !unary(suites);
+    } else if (input.nextIs('(')) {
+        input.get();
+        const unary = parseDisjunction(input);
+        if (!input.nextIs(')')) {
+            const message = "Expected ')'";
+            throw TypeError(message);
+        }
+        input.get();
+        return unary;
+    } else {
+        return parseTerm(input);
+    }
+}
+
+// TERM
+function parseTerm(input: PeekableSequence<string>): SuitePredicate {
+    if (!input.atEOS()) {
+        const next = input.peek();
+        if (['&', '|', '!', '(', ')'].includes(next)) {
+            const message = `Unexpected operator "${next}"`;
+            throw TypeError(message);
+        }
+        const suite = input.get();
+        return (suites: string[]) => suites.includes(suite);
+    } else {
+        const message = 'Expected a suite';
+        throw TypeError(message);
+    }
+}

--- a/src/test_suite/suite_filter.ts
+++ b/src/test_suite/suite_filter.ts
@@ -12,10 +12,22 @@ type SuitePredicate = (suites: string[]) => boolean;
 //   PARENTHESES: '(', ')'
 //
 // The SuitePredicate takes a single parameter that is an array of
-// TERMS, each of which is considered to have a true value. It returns
-// the truth value of the expression.
+// TERMS whose values are considered to be true. All other terms (those
+// that don't appear on the list) are considered to be false. The
+// SuitePredicate returns the truth value of the expression.
+//
+// So, for example, if the suites parameter of the SuitePredicate was
+//   ['a', 'b']
+// then the following expressions would evaluate to true:
+//   'a'
+//   'b'
+//   'a & b'
+// and the following expressions would evaluate to false:
+//   'x'
+//   '!a'
+//
 export function suiteFilter(text: string): SuitePredicate {
-    // Tokenzize the input string.
+    // Tokenize the input string.
     // The result should be an array of suite names, and symbols '(', ')', '&',
     // '|', and '!'.
     const re = new RegExp('s*([\\s+|\\&\\|\\!\\(\\)])');

--- a/src/test_suite/suite_filter.ts
+++ b/src/test_suite/suite_filter.ts
@@ -1,6 +1,9 @@
 import { PeekableSequence } from './peekable_sequence';
 
-type SuitePredicate = (suites: string[]) => boolean;
+export type SuitePredicate = (suites: string[]) => boolean;
+
+// A suite predicate that matches all suites.
+export const allSuites: SuitePredicate = (suites: string[]) => true;
 
 // Constructs a SuitePredicate from a a textual boolean expression
 // over suite names. The expression can be made up of
@@ -30,7 +33,7 @@ export function suiteFilter(text: string): SuitePredicate {
     // Tokenize the input string.
     // The result should be an array of suite names, and symbols '(', ')', '&',
     // '|', and '!'.
-    const re = new RegExp('s*([\\s+|\\&\\|\\!\\(\\)])');
+    const re = new RegExp('([\\s+|\\&\\|\\!\\(\\)])');
     const tokens = text
         .split(re)
         .map(x => x.trim())

--- a/src/test_suite/test_runner_main.ts
+++ b/src/test_suite/test_runner_main.ts
@@ -75,8 +75,14 @@ export async function testRunnerMain(
     }
 
     let runOneTest: number | undefined = undefined;
-    if (args['n']) {
-        runOneTest = Number(args['n']);
+    if (args['n'] !== undefined) {
+        const n = Number(args['n']);
+        if (!Number.isNaN(n)) {
+            runOneTest = Number(n);
+        } else {
+            const message = 'Expected test number after -n flag.';
+            fail(message);
+        }
     }
 
     //

--- a/src/test_suite/test_runner_main.ts
+++ b/src/test_suite/test_runner_main.ts
@@ -8,6 +8,7 @@ import { createWorld, Processor, World } from '../processors';
 import { createMarkdown } from './print_markdown';
 import { TestProcessors } from './test_processors';
 import { TestSuite } from './test_suite';
+import { allSuites, suiteFilter } from './suite_filter';
 
 export async function testRunnerMain(
     title: string,
@@ -128,12 +129,15 @@ export async function testRunnerMain(
     //
     // Run the tests
     //
-    let suiteFilter = args['s'];
+    const suiteExpressionText = args['s'];
+    let suiteExpression = allSuites;
     if (runOneTest !== undefined) {
         console.log(`Running test number ${runOneTest}.`);
-        suiteFilter = undefined;
-    } else if (suiteFilter) {
-        console.log(`Running tests in suite: ${suiteFilter}`);
+    } else if (suiteExpressionText) {
+        console.log(
+            `Running tests in matching suite expression: ${suiteExpressionText}`
+        );
+        suiteExpression = suiteFilter(suiteExpressionText);
     } else {
         console.log('Running all tests.');
     }
@@ -163,7 +167,7 @@ export async function testRunnerMain(
     if (brief) {
         console.log(' ');
         console.log('Displaying test utterances without running.');
-        for (const test of suite.filteredTests(suiteFilter)) {
+        for (const test of suite.filteredTests(suiteExpression)) {
             console.log(`Test ${test.id}: ${test.comment}`);
             for (const line of test.inputs) {
                 console.log(`  ${line}`);
@@ -177,7 +181,7 @@ export async function testRunnerMain(
         const aggregator = await suite.run(
             processor,
             world.catalog,
-            suiteFilter,
+            suiteExpression,
             isomorphic,
             !skipIntermediate
         );

--- a/test/test_suite/suite_filter.test.ts
+++ b/test/test_suite/suite_filter.test.ts
@@ -12,57 +12,77 @@ describe('suite_filter', () => {
     const suites = ['a', 'b', 'c', 'd'];
     const suites2 = ['foo', 'bar', 'foo-bar'];
 
-    it('parse', () => {
+    it('TERM', () => {
         // Simple TERM
         assert.isTrue(suiteFilter('a')(suites));
         assert.isTrue(suiteFilter('b')(suites));
         assert.isFalse(suiteFilter('x')(suites));
+    });
 
+    it('!TERM', () => {
         // Simple !TERM
         assert.isFalse(suiteFilter('!a')(suites));
         assert.isFalse(suiteFilter('!b')(suites));
         assert.isTrue(suiteFilter('!x')(suites));
+    });
 
+    it('(TERM)', () => {
         // Simple (TERM)
         assert.isTrue(suiteFilter('(a)')(suites));
         assert.isFalse(suiteFilter('(x)')(suites));
+    });
 
+    it('Simple CONJUNCTIONS', () => {
         // Simple CONJUNCTION
         assert.isTrue(suiteFilter('a & b')(suites));
         assert.isTrue(suiteFilter('a & b & c')(suites));
         assert.isFalse(suiteFilter('a & x')(suites));
         assert.isFalse(suiteFilter('a & b & x')(suites));
+    });
 
+    it('Simple DISJUNCTIONS', () => {
         // Simple DISJUNCTION
         assert.isTrue(suiteFilter('a | b')(suites));
         assert.isTrue(suiteFilter('a | x')(suites));
         assert.isTrue(suiteFilter('x | y | z | a')(suites));
         assert.isFalse(suiteFilter('x | y')(suites));
+    });
 
+    it('Complex NEGATIONS', () => {
         // Complex NEGATION
         assert.isTrue(suiteFilter('!(x & y)')(suites));
         assert.isFalse(suiteFilter('!(a | b)')(suites));
+    });
 
+    it('Operator precedence', () => {
         // Operator precedence
         assert.isTrue(suiteFilter('x & a | b')(suites));
         assert.isTrue(suiteFilter('(x & a) | b')(suites));
         assert.isFalse(suiteFilter('x & (a | b)')(suites));
+    });
 
+    it('Complex ()', () => {
         // Complex ()
         assert.isTrue(
             suiteFilter('((a | x) & (b | y) & ((c | x) | (d | y)))')(suites)
         );
+    });
 
+    it('Multi-character suite names', () => {
         // Suite names
         assert.isTrue(suiteFilter('foo')(suites2));
         assert.isTrue(suiteFilter('bar')(suites2));
         assert.isTrue(suiteFilter('foo-bar')(suites2));
         assert.isTrue(suiteFilter('foo & bar & !baz-baz')(suites2));
+    });
 
+    it('White space', () => {
         // White space
         assert.isTrue(suiteFilter('    a   &b & c   ')(suites));
         assert.isTrue(suiteFilter('a&b&c')(suites));
+    });
 
+    it('Malformed expressions', () => {
         // Malformed expressions
         assert.throws(() => suiteFilter('(a&b')(suites), "Expected ')'");
         assert.throws(() => suiteFilter('(a|b')(suites), "Expected ')'");

--- a/test/test_suite/suite_filter.test.ts
+++ b/test/test_suite/suite_filter.test.ts
@@ -1,0 +1,96 @@
+import { assert } from 'chai';
+import 'mocha';
+
+import { suiteFilter } from '../../src/test_suite';
+
+describe('suite_filter', () => {
+    ///////////////////////////////////////////////////////////////////////////////
+    //
+    //  Suite Filter
+    //
+    ///////////////////////////////////////////////////////////////////////////////
+    const suites = ['a', 'b', 'c', 'd'];
+    const suites2 = ['foo', 'bar', 'foo-bar'];
+
+    it('parse', () => {
+        // Simple TERM
+        assert.isTrue(suiteFilter('a')(suites));
+        assert.isTrue(suiteFilter('b')(suites));
+        assert.isFalse(suiteFilter('x')(suites));
+
+        // Simple !TERM
+        assert.isFalse(suiteFilter('!a')(suites));
+        assert.isFalse(suiteFilter('!b')(suites));
+        assert.isTrue(suiteFilter('!x')(suites));
+
+        // Simple (TERM)
+        assert.isTrue(suiteFilter('(a)')(suites));
+        assert.isFalse(suiteFilter('(x)')(suites));
+
+        // Simple CONJUNCTION
+        assert.isTrue(suiteFilter('a & b')(suites));
+        assert.isTrue(suiteFilter('a & b & c')(suites));
+        assert.isFalse(suiteFilter('a & x')(suites));
+        assert.isFalse(suiteFilter('a & b & x')(suites));
+
+        // Simple DISJUNCTION
+        assert.isTrue(suiteFilter('a | b')(suites));
+        assert.isTrue(suiteFilter('a | x')(suites));
+        assert.isTrue(suiteFilter('x | y | z | a')(suites));
+        assert.isFalse(suiteFilter('x | y')(suites));
+
+        // Complex NEGATION
+        assert.isTrue(suiteFilter('!(x & y)')(suites));
+        assert.isFalse(suiteFilter('!(a | b)')(suites));
+
+        // Operator precedence
+        assert.isTrue(suiteFilter('x & a | b')(suites));
+        assert.isTrue(suiteFilter('(x & a) | b')(suites));
+        assert.isFalse(suiteFilter('x & (a | b)')(suites));
+
+        // Complex ()
+        assert.isTrue(
+            suiteFilter('((a | x) & (b | y) & ((c | x) | (d | y)))')(suites)
+        );
+
+        // Suite names
+        assert.isTrue(suiteFilter('foo')(suites2));
+        assert.isTrue(suiteFilter('bar')(suites2));
+        assert.isTrue(suiteFilter('foo-bar')(suites2));
+        assert.isTrue(suiteFilter('foo & bar & !baz-baz')(suites2));
+
+        // White space
+        assert.isTrue(suiteFilter('    a   &b & c   ')(suites));
+        assert.isTrue(suiteFilter('a&b&c')(suites));
+
+        // Malformed expressions
+        assert.throws(() => suiteFilter('(a&b')(suites), "Expected ')'");
+        assert.throws(() => suiteFilter('(a|b')(suites), "Expected ')'");
+        assert.throws(() => suiteFilter('a&')(suites), 'Expected a suite');
+        assert.throws(() => suiteFilter('a |')(suites), 'Expected a suite');
+        assert.throws(
+            () => suiteFilter('&')(suites),
+            'Unexpected operator "&"'
+        );
+        assert.throws(
+            () => suiteFilter('|')(suites),
+            'Unexpected operator "|"'
+        );
+        assert.throws(() => suiteFilter('!')(suites), 'Expected a suite');
+        assert.throws(() => suiteFilter('(')(suites), 'Expected a suite');
+        assert.throws(
+            () => suiteFilter(')')(suites),
+            'Unexpected operator ")"'
+        );
+        assert.throws(
+            () => suiteFilter('a b')(suites),
+            "Expected '&' or '|' operator"
+        );
+        assert.throws(
+            () => suiteFilter('(a+b))')(suites),
+            "Expected '&' or '|' operator"
+        );
+        assert.throws(() => suiteFilter('')(suites), 'Expected a suite');
+        assert.throws(() => suiteFilter('   ')(suites), 'Expected a suite');
+    });
+});


### PR DESCRIPTION
This is the first step in implementing suite filter expressions for TestSuite. Eventually, one should be able to use boolean expressions with the -s flag:

~~~
% node build/samples/test_runner.js test.yaml -s="ready & !deprecated"
~~~