### PR TITLE
Fix short-order regression related to addToItemWithReplacement():

### DIFF
--- a/src/cart/cart_ops.ts
+++ b/src/cart/cart_ops.ts
@@ -63,21 +63,18 @@ export class CartOps implements ICartOps {
         child: ItemInstance
     ): ItemInstance {
         let inserted = false;
-        const f = this.ruleChecker.getIncrementalMutualExclusionPredicate(
-            parent.key
+        const f = this.ruleChecker.getPairwiseMutualExclusionPredicate(
+            parent.key,
+            child.key
         );
         const newChildren: ItemInstance[] = [];
         for (const c of parent.children) {
-            const existingPID = AttributeInfo.pidFromKey(c.key).toString();
-            const childPID = AttributeInfo.pidFromKey(child.key).toString();
-            if (existingPID !== childPID) {
-                if (f(c.key)) {
-                    newChildren.push(c);
-                } else {
-                    if (!inserted) {
-                        inserted = true;
-                        newChildren.push(child);
-                    }
+            if (f(c.key)) {
+                newChildren.push(c);
+            } else {
+                if (!inserted) {
+                    inserted = true;
+                    newChildren.push(child);
                 }
             }
         }

--- a/src/rule_checker/interfaces.ts
+++ b/src/rule_checker/interfaces.ts
@@ -53,8 +53,6 @@ export interface IRuleChecker {
     getValidChildren(parent: Key): Set<PID>;
 
     /**
-     * @deprecated Please use getIncrementalMutualExclusionPredicate
-     *
      * Given the key of a parent item (parent) and the key of a child item
      * (child) return a curried function that indicates whether another child
      * (existing) would violate mutual exclusivity.

--- a/test/rule_checker/rule_checker.test.ts
+++ b/test/rule_checker/rule_checker.test.ts
@@ -306,12 +306,17 @@ describe('RuleChecker', () => {
                 wholeMilkKey
             );
 
+            // We can't add whole milk because parent already has a milk.
             assert.isFalse(f(wholeMilkKey));
+
+            // We can add something that is not milk.
             assert.isTrue(f(someOtherKey1));
+
+            // We can't add soy milk because parent already has a milk.
             assert.isFalse(f(soyMilkKey));
-            assert.isTrue(f(someOtherKey2));
+
+            // We can't add two percent milk because parent already has a milk.
             assert.isFalse(f(twoMilkKey));
-            assert.isFalse(f(someOtherKey2));
         });
     });
 


### PR DESCRIPTION
[PR 94](https://github.com/MikeHopcroft/PrixFixe/pull/94) introduced a regression in short-order. This new PR rolls back some of the PR 94 changes and attempts to fix the underlying problem.