### PR TITLE
Adding junit output option to testrunner

### DIFF
--- a/src/test_suite/test_runner_main.ts
+++ b/src/test_suite/test_runner_main.ts
@@ -96,6 +96,7 @@ export async function testRunnerMain(
     }
 
     const generate = args['g'];
+    const outputPath = args['o'];
 
     const correctionLevelFlag = args['c'] || 'scoped';
     const correctionLevel = getCorrectionLevel(correctionLevelFlag);
@@ -270,6 +271,12 @@ export async function testRunnerMain(
             const newResults = results.rebase();
             await fs.writeFileSync(outfile, safeDump(newResults));
         }
+
+        if (outputPath) {
+            console.log(`Writing results to '${outputPath}'`);
+            fs.writeFileSync(path.resolve(outputPath), results.toJUnitXml());
+        }
+
         return succeed(true);
     }
 }
@@ -362,7 +369,13 @@ function showUsage(processorFactory: TestProcessors) {
                     alias: 'g',
                     typeLabel: '{underline outputFilePath}',
                     description:
-                        'Output file to save generated cart results. Not compatible with {bold -p}',
+                        'Output file to save generated cart results. Not compatible with directories, single file only.',
+                },
+                {
+                    name: 'output',
+                    alias: 'o',
+                    typeLabel: '{underline outputFilePath}',
+                    description: 'Path to output results in JUnit format',
                 },
                 {
                     name: 'd',


### PR DESCRIPTION
This was a feature in the ramsay test-runner that I forgot to move over. It may be used for CI/CD pipelines so I don't want to leave it out.