### PR TITLE
SKU to key lookup in Catalog

### DIFF
--- a/src/catalog/catalog.ts
+++ b/src/catalog/catalog.ts
@@ -5,6 +5,7 @@ import {
     ICatalog,
     Key,
     PID,
+    SKU,
     SpecificTypedEntity,
 } from './interfaces';
 
@@ -12,6 +13,7 @@ export class Catalog implements ICatalog {
     private mapGeneric = new Map<PID, GenericTypedEntity>();
     private mapSpecific = new Map<Key, SpecificTypedEntity>();
     private pidToKeys = new Map<PID, Key[]>();
+    private skuToKey = new Map<SKU, Key>();
 
     static fromEntities(
         genericItems: IterableIterator<GenericTypedEntity>,
@@ -71,6 +73,15 @@ export class Catalog implements ICatalog {
             } else {
                 keys.push(item.key);
             }
+
+            if (this.skuToKey.has(item.sku)) {
+                throw TypeError(
+                    `Catalog: encountered duplicate sku ${item.sku}.`
+                );
+            }
+
+            // Add SKU to key mapping
+            this.skuToKey.set(item.sku, item.key);
         }
     }
 
@@ -105,6 +116,14 @@ export class Catalog implements ICatalog {
 
     hasKey(key: Key): boolean {
         return this.mapSpecific.has(key);
+    }
+
+    getKeyForSku(sku: SKU): Key {
+        const key = this.skuToKey.get(sku);
+        if (!key) {
+            throw TypeError(`Catalog.get(): cannot find sku=${sku}`);
+        }
+        return key;
     }
 
     getSpecific(key: Key): SpecificTypedEntity {

--- a/test/catalog/catalog.test.ts
+++ b/test/catalog/catalog.test.ts
@@ -178,7 +178,7 @@ describe('Catalog', () => {
                 smallVanillaCone.key
             );
         });
-        it('should throw on ', () => {
+        it('should throw on invalid SKU', () => {
             const catalog = Catalog.fromCatalog(testCatalog);
 
             expect(() => catalog.getKeyForSku(123987456)).to.throw(TypeError);

--- a/test/catalog/catalog.test.ts
+++ b/test/catalog/catalog.test.ts
@@ -170,6 +170,21 @@ describe('Catalog', () => {
         });
     });
 
+    describe('getKeyForSku', () => {
+        it('should return a key for the right SKU', () => {
+            const catalog = Catalog.fromCatalog(testCatalog);
+            assert.equal(
+                catalog.getKeyForSku(smallVanillaCone.sku),
+                smallVanillaCone.key
+            );
+        });
+        it('should throw on ', () => {
+            const catalog = Catalog.fromCatalog(testCatalog);
+
+            expect(() => catalog.getKeyForSku(123987456)).to.throw(TypeError);
+        });
+    });
+
     describe('getSpecific', () => {
         it('should return SpecificTypedEntity if key is found', () => {
             const catalog = Catalog.fromCatalog(testCatalog);


### PR DESCRIPTION
There exist cases where one would want to lookup the specific `key` for a given `SKU`.

This PR adds a function to the catalog to perform this lookup 